### PR TITLE
Fix NPM compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt": "~0.4.1",
     "grunt-contrib-uglify": "~0.2.4"
   },
+  "main": "src/uxhr.js",
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {},


### PR DESCRIPTION
Without specifying the main script in package.json you can't import this with Node.
